### PR TITLE
fix(zep): skip empty messages and ignore NotFoundError in fetchKnowledge

### DIFF
--- a/zep/session.go
+++ b/zep/session.go
@@ -109,6 +109,9 @@ func (s *SessionService) AppendEvent(ctx context.Context, sess session.Session, 
 			}
 		}
 	}
+	if contentStr == "" {
+		return nil
+	}
 
 	msg := &zep.Message{
 		Role:    zepRole,
@@ -182,6 +185,10 @@ func (s *SessionService) fetchKnowledge(ctx context.Context, sessionID string, t
 		TemplateID: templateID,
 	})
 	if err != nil {
+		var notFound *zep.NotFoundError
+		if errors.As(err, &notFound) {
+			return "", nil
+		}
 		return "", err
 	}
 


### PR DESCRIPTION
AppendEvent now returns early when no text content is extracted, preventing empty messages from being written to Zep for tool call and function response events.

fetchKnowledge now treats NotFoundError from GetUserContext as a non-error condition (no knowledge available yet), mirroring the ensureUser pattern, so Get() no longer fails spuriously for sessions without extracted facts.