### PR TITLE
fix(openai, zep): propagate marshal error and fix history speaker format

### DIFF
--- a/openai/model.go
+++ b/openai/model.go
@@ -320,7 +320,11 @@ func contentsToMessages(contents []*genai.Content) ([]oai.ChatCompletionMessageP
 			}
 			msgs = append(msgs, userMsgs...)
 		case genai.RoleModel:
-			msgs = append(msgs, modelContentToMessage(c))
+			msg, err := modelContentToMessage(c)
+			if err != nil {
+				return nil, err
+			}
+			msgs = append(msgs, msg)
 		default:
 			// Unknown roles are silently skipped. Future roles added to genai
 			// will not cause a hard failure but will not be mapped either.
@@ -388,7 +392,7 @@ func functionResponseToToolMessage(fr *genai.FunctionResponse) oai.ChatCompletio
 
 // modelContentToMessage converts a model-role genai.Content to an OpenAI
 // assistant message.  Text and function calls may coexist in a single message.
-func modelContentToMessage(c *genai.Content) oai.ChatCompletionMessageParamUnion {
+func modelContentToMessage(c *genai.Content) (oai.ChatCompletionMessageParamUnion, error) {
 	var textBuf strings.Builder
 	var toolCalls []oai.ChatCompletionMessageToolCallParam
 
@@ -399,7 +403,10 @@ func modelContentToMessage(c *genai.Content) oai.ChatCompletionMessageParamUnion
 		if part.Text != "" {
 			textBuf.WriteString(part.Text)
 		} else if part.FunctionCall != nil {
-			b, _ := json.Marshal(part.FunctionCall.Args)
+			b, err := json.Marshal(part.FunctionCall.Args)
+			if err != nil {
+				return oai.ChatCompletionMessageParamUnion{}, fmt.Errorf("openai: marshal function call args: %w", err)
+			}
 			toolCalls = append(toolCalls, oai.ChatCompletionMessageToolCallParam{
 				ID: part.FunctionCall.ID,
 				Function: oai.ChatCompletionMessageToolCallFunctionParam{
@@ -417,7 +424,7 @@ func modelContentToMessage(c *genai.Content) oai.ChatCompletionMessageParamUnion
 	if len(toolCalls) > 0 {
 		asst.ToolCalls = toolCalls
 	}
-	return oai.ChatCompletionMessageParamUnion{OfAssistant: &asst}
+	return oai.ChatCompletionMessageParamUnion{OfAssistant: &asst}, nil
 }
 
 // declarationsToTools converts genai tool definitions to OpenAI tool params.

--- a/zep/session.go
+++ b/zep/session.go
@@ -229,7 +229,7 @@ func (s *SessionService) fetchHistory(ctx context.Context, sessionID string) ([]
 
 		content := msg.Content
 		if msg.Name != nil && *msg.Name != "" {
-			content = fmt.Sprintf("%s (%s): %s", *msg.Name, msg.Role, content)
+			content = fmt.Sprintf("<speaker name=%q/>\n%s", *msg.Name, content)
 		}
 		evt.LLMResponse = model.LLMResponse{
 			Content: genai.NewContentFromText(content, genai.Role(contentRole)),


### PR DESCRIPTION
Fixes #13

**Bug 1 — openai/model.go**: Change `modelContentToMessage` signature to return `(oai.ChatCompletionMessageParamUnion, error)` and propagate the `json.Marshal` error wrapped as `"openai: marshal function call args: %w"` instead of silently discarding it. Update the caller in `contentsToMessages` to handle and propagate the error.

**Bug 2 — zep/session.go**: Change speaker attribution format in `fetchHistory` from `"name (role): text"` (chat-log style, imitated verbatim by GPT models) to `"<speaker name=\"name\"/>\ntext"` (XML annotation style, treated as structural metadata). No changes required in any model provider or consuming application.

Generated with [Claude Code](https://claude.ai/code)