### PR TITLE
fix(session): update decoratedSession.events in AppendEvent

### DIFF
--- a/session/options.go
+++ b/session/options.go
@@ -81,6 +81,15 @@ func (d *decoratedService) AppendEvent(ctx context.Context, sess session.Session
 		return nil
 	}
 
+	// Update the decorator's event snapshot before any persistence guard so
+	// every appended event is visible via ctx.Session().Events() within the
+	// current turn, even when persistence is suppressed. Unwrap to the base
+	// session so the underlying service receives the session it created.
+	if ds, ok := sess.(*decoratedSession); ok {
+		ds.events = append(ds.events, event)
+		sess = ds.Session
+	}
+
 	isUser := event.Author == "user" || event.Author == "human"
 	if isUser && !d.persistUser {
 		return nil


### PR DESCRIPTION
Fixes #16

`decoratedService.AppendEvent` was not updating the in-memory event snapshot on `decoratedSession`, causing `ctx.Session().Events()` to return a stale slice that excluded the current turn's appended events. The LLM therefore always responded to the previous user message.

Two complementary fixes:
1. Append to `ds.events` before the persistence guard so every event is visible via `Events()` within the current turn, even when persistence is suppressed.
2. Unwrap to `ds.Session` before delegating to `d.base.AppendEvent` so the underlying service receives the session it created — preventing silent type-assertion failures in concrete implementations that maintain their own in-memory state.

Generated with [Claude Code](https://claude.ai/code)