### PR TITLE
refactor: follow-up refinements for Zep session service (issue #20)

### DIFF
--- a/session/options.go
+++ b/session/options.go
@@ -4,16 +4,13 @@ import (
 	"context"
 	"iter"
 
-	"google.golang.org/adk/model"
 	"google.golang.org/adk/session"
-	"google.golang.org/genai"
 )
 
 type decoratedService struct {
 	base         session.Service
 	persistUser  bool
 	persistAgent bool
-	policy       string
 	timezoneKey  any // external context key bridged to TimezoneKey per-request
 }
 
@@ -28,12 +25,6 @@ func WithoutUserMessagePersistence() Option {
 func WithoutAgentResponsePersistence() Option {
 	return func(d *decoratedService) {
 		d.persistAgent = false
-	}
-}
-
-func WithPolicy(instruction string) Option {
-	return func(d *decoratedService) {
-		d.policy = instruction
 	}
 }
 
@@ -126,27 +117,12 @@ func (d *decoratedService) Get(ctx context.Context, req *session.GetRequest) (*s
 		assembled = append(assembled, e)
 	}
 
-	if d.policy != "" {
-		assembled = append(assembled, d.newSystemEvent("policy", d.policy))
-	}
-
 	return &session.GetResponse{
 		Session: &decoratedSession{
 			Session: sess,
 			events:  assembled,
 		},
 	}, nil
-}
-
-func (d *decoratedService) newSystemEvent(category, content string) *session.Event {
-	evt := session.NewEvent(category)
-	evt.Author = "system"
-
-	evt.LLMResponse = model.LLMResponse{
-		Content: genai.NewContentFromText(content, genai.Role("model")),
-	}
-
-	return evt
 }
 
 type decoratedSession struct {

--- a/zep/session.go
+++ b/zep/session.go
@@ -376,7 +376,7 @@ func (s *SessionService) resolveLocation(ctx context.Context) (*time.Location, e
 
 func (s *SessionService) buildPreamble() string {
 	if s.timeHarnessEnabled {
-		return `[MESSAGE_HISTORY_FORMAT]
+		return `[MESSAGES_HISTORY_FORMAT]
 The conversation history below uses this format:
 
   [YYYY-MM-DD HH:MM Name] raw message content
@@ -388,9 +388,9 @@ always the user's local time.
 
 IMPORTANT: Never produce responses with this bracketed prefix. Respond
 with raw message content only.
-[/MESSAGE_HISTORY_FORMAT]`
+[/MESSAGES_HISTORY_FORMAT]`
 	}
-	return `[MESSAGE_HISTORY_FORMAT]
+	return `[MESSAGES_HISTORY_FORMAT]
 The conversation history below uses this format:
 
   [Name] raw message content
@@ -400,20 +400,20 @@ identification.
 
 IMPORTANT: Never produce responses with this bracketed prefix. Respond
 with raw message content only.
-[/MESSAGE_HISTORY_FORMAT]`
+[/MESSAGES_HISTORY_FORMAT]`
 }
 
 func (s *SessionService) buildPostamble() string {
 	if s.timeHarnessEnabled {
-		return `[END_OF_MESSAGE_HISTORY]
-Reminder: never respond with the [YYYY-MM-DD HH:MM Name] format. Output
+		return `[CRITICAL_FORMAT_REMINDER]
+CRITICAL: Do not respond using the [YYYY-MM-DD HH:MM Name] format. Output
 raw message content only.
-[/END_OF_MESSAGE_HISTORY]`
+[/CRITICAL_FORMAT_REMINDER]`
 	}
-	return `[END_OF_MESSAGE_HISTORY]
-Reminder: never respond with the [Name] format. Output raw message
+	return `[CRITICAL_FORMAT_REMINDER]
+CRITICAL: Do not respond using the [Name] format. Output raw message
 content only.
-[/END_OF_MESSAGE_HISTORY]`
+[/CRITICAL_FORMAT_REMINDER]`
 }
 
 func (s *SessionService) buildCurrentTimeAnchor(loc *time.Location, lastTime time.Time) string {
@@ -431,14 +431,17 @@ func (s *SessionService) buildCurrentTimeAnchor(loc *time.Location, lastTime tim
 }
 
 // formatElapsed returns a human-readable duration.
+// Pluralization is always-plural by design (e.g. "1 minutes") — LLMs
+// tolerate this and avoiding plural/singular branching keeps the
+// function simple.
 //
-//	< 1 minute  → "less than a minute"
+//	< 1 minute  → "N seconds"
 //	< 60 min    → "N minutes"
 //	< 24 hours  → "H hours M minutes"
-//	≥ 24 hours  → "D days H hours"
+//	≥ 24 hours  → "D days H hours M minutes"
 func formatElapsed(d time.Duration) string {
 	if d < time.Minute {
-		return "less than a minute"
+		return fmt.Sprintf("%d seconds", int(d.Seconds()))
 	}
 	if d < time.Hour {
 		return fmt.Sprintf("%d minutes", int(d.Minutes()))
@@ -448,9 +451,12 @@ func formatElapsed(d time.Duration) string {
 		m := int(d.Minutes()) - h*60
 		return fmt.Sprintf("%d hours %d minutes", h, m)
 	}
-	days := int(d.Hours() / 24)
-	h := int(d.Hours()) - days*24
-	return fmt.Sprintf("%d days %d hours", days, h)
+	totalMinutes := int(d.Minutes())
+	days := totalMinutes / (24 * 60)
+	remaining := totalMinutes - days*24*60
+	h := remaining / 60
+	m := remaining - h*60
+	return fmt.Sprintf("%d days %d hours %d minutes", days, h, m)
 }
 
 func (s *SessionService) unmapRole(role zep.RoleType) string {
@@ -480,8 +486,9 @@ func (s *SessionService) Delete(_ context.Context, _ *adksession.DeleteRequest) 
 }
 
 // parseTimestamp tries RFC3339Nano then RFC3339. Returns false when neither
-// matches, allowing callers to skip the timestamp prefix gracefully rather
-// than surface a parse error to the LLM.
+// matches. When TimeHarness is enabled, fetchHistory treats false as a
+// hard error (invariant violation). When TimeHarness is disabled, the
+// caller path does not invoke parseTimestamp at all.
 func parseTimestamp(s string) (time.Time, bool) {
 	if t, err := time.Parse(time.RFC3339Nano, s); err == nil {
 		return t, true

--- a/zep/session_test.go
+++ b/zep/session_test.go
@@ -303,10 +303,10 @@ func TestEvents_EmptyHistory_NoPreambleNoPostamble(t *testing.T) {
 	events := runBuildContext(t, svc, context.Background())
 
 	for _, text := range systemTexts(events) {
-		if strings.HasPrefix(text, "[MESSAGE_HISTORY_FORMAT]") {
+		if strings.HasPrefix(text, "[MESSAGES_HISTORY_FORMAT]") {
 			t.Error("expected no format_preamble event for empty history")
 		}
-		if strings.HasPrefix(text, "[END_OF_MESSAGE_HISTORY]") {
+		if strings.HasPrefix(text, "[CRITICAL_FORMAT_REMINDER]") {
 			t.Error("expected no format_postamble event for empty history")
 		}
 	}
@@ -388,15 +388,66 @@ func TestFormatElapsed_Buckets(t *testing.T) {
 		d    time.Duration
 		want string
 	}{
-		{30 * time.Second, "less than a minute"},
+		{0 * time.Second, "0 seconds"},
+		{30 * time.Second, "30 seconds"},
+		{59 * time.Second, "59 seconds"},
+		{60 * time.Second, "1 minutes"},
 		{65 * time.Second, "1 minutes"},
+		{59 * time.Minute, "59 minutes"},
+		{60 * time.Minute, "1 hours 0 minutes"},
 		{90 * time.Minute, "1 hours 30 minutes"},
-		{50 * time.Hour, "2 days 2 hours"},
+		{23*time.Hour + 59*time.Minute, "23 hours 59 minutes"},
+		{24 * time.Hour, "1 days 0 hours 0 minutes"},
+		{50 * time.Hour, "2 days 2 hours 0 minutes"},
+		{50*time.Hour + 17*time.Minute, "2 days 2 hours 17 minutes"},
 	}
 	for _, c := range cases {
 		got := formatElapsed(c.d)
 		if got != c.want {
 			t.Errorf("formatElapsed(%v) = %q, want %q", c.d, got, c.want)
 		}
+	}
+}
+
+func TestEvents_Order_PreambleHistoryPostambleCurrentTime(t *testing.T) {
+	ts := "2026-05-17T05:57:00Z"
+	msgs := []*zepgo.Message{
+		{
+			Role:      zepgo.RoleTypeUserRole,
+			Content:   "hello",
+			Name:      ptr("Ian"),
+			CreatedAt: ptr(ts),
+		},
+	}
+	svc := newTestService(msgs, WithTimeHarness("Asia/Jakarta"))
+	events := runBuildContext(t, svc, context.Background())
+
+	// Expected sequence: preamble, history, postamble, current_time
+	if len(events) != 4 {
+		t.Fatalf("expected 4 events, got %d", len(events))
+	}
+
+	// 0: preamble
+	if events[0].Author != "system" ||
+		!strings.HasPrefix(eventText(t, events[0]), "[MESSAGES_HISTORY_FORMAT]") {
+		t.Errorf("position 0 should be preamble, got author=%q text=%q",
+			events[0].Author, eventText(t, events[0]))
+	}
+	// 1: history (non-system)
+	if events[1].Author == "system" {
+		t.Errorf("position 1 should be history (non-system), got system event: %q",
+			eventText(t, events[1]))
+	}
+	// 2: postamble
+	if events[2].Author != "system" ||
+		!strings.HasPrefix(eventText(t, events[2]), "[CRITICAL_FORMAT_REMINDER]") {
+		t.Errorf("position 2 should be postamble, got author=%q text=%q",
+			events[2].Author, eventText(t, events[2]))
+	}
+	// 3: current_time
+	if events[3].Author != "system" ||
+		!strings.HasPrefix(eventText(t, events[3]), "[CURRENT_TIME]") {
+		t.Errorf("position 3 should be current_time, got author=%q text=%q",
+			events[3].Author, eventText(t, events[3]))
 	}
 }


### PR DESCRIPTION
Follow-up refinements from issue #20:

- Remove `WithPolicy` from `session/options.go` entirely
- Rename preamble tag to `[MESSAGES_HISTORY_FORMAT]` (plural)
- Rename postamble tag to `[CRITICAL_FORMAT_REMINDER]` with "CRITICAL:" framing
- Update `formatElapsed`: sub-minute returns seconds; ≥24h includes minutes
- Update `TestFormatElapsed_Buckets` to match new semantics
- Add `TestEvents_Order_PreambleHistoryPostambleCurrentTime` ordering invariant test
- Update `parseTimestamp` doc comment for hard-fail semantics

Closes #20

Generated with [Claude Code](https://claude.ai/code)